### PR TITLE
Fix: Reset inring flag on input atoms in BuildSSSR

### DIFF
--- a/xdrawchem/xdrawchem/molecule_sssr.cpp
+++ b/xdrawchem/xdrawchem/molecule_sssr.cpp
@@ -107,6 +107,10 @@ void SSSR::BuildSSSR( QList < DPoint * >alist )
     sssr.clear();
     sssr_data.clear();
 
+    for (DPoint *pt : alist) {
+        if (pt) pt->inring = false;
+    }
+
     int atomsRemoved;
 
     structureAtoms = alist;


### PR DESCRIPTION
Observed a test failure on OpenBSD where acyclic chain atoms were falsely flagged as being part of a ring structure. The issue occurred because the inring status on DPoint atoms was never explicitly initialized or reset at the start of the Smallest Set of Smallest Rings (SSSR) detection algorithm. As a result, stale data or uninitialized state flags from previous test cases/calculations persisted, causing QVERIFY(!pt->inring) to fail on linear chains even when the algorithm correctly determined that zero ring atoms existed.

Failing test output:

```
5: INFO : TestSSSR::linear_chain_atoms_not_inring() entering
5: QINFO : TestSSSR::linear_chain_atoms_not_inring() 0 : 1
5: QINFO : TestSSSR::linear_chain_atoms_not_inring() 3 : 1
5: QINFO : TestSSSR::linear_chain_atoms_not_inring() 3 : 1
5: QINFO : TestSSSR::linear_chain_atoms_not_inring() 1 : 1
5: QINFO : TestSSSR::linear_chain_atoms_not_inring() 2 : 0
5: QINFO : TestSSSR::linear_chain_atoms_not_inring() There are 0 ring atoms
5: INFO : TestSSSR::linear_chain_atoms_not_inring() QVERIFY(!pt->inring)
5: Loc: [/usr/ports/pobj/xdrawchem-2.0.1/xdrawchem-2.0.1/xdrawchem-qt5/tests/tst_sssr.cpp(159)]
5: FAIL! : TestSSSR::linear_chain_atoms_not_inring() '!pt->inring' returned FALSE. (Chain atoms must NOT be flagged in-ring)
5: Loc: [/usr/ports/pobj/xdrawchem-2.0.1/xdrawchem-2.0.1/xdrawchem-qt5/tests/tst_sssr.cpp(159)]
```

Fix by adding an explicit loop at the beginning of SSSR::BuildSSSR to clear and reset the inring flag to false for all input atoms.