### PR TITLE
Fix SIGSEGV crash during 1H NMR calculation on OpenBSD

### DIFF
--- a/xdrawchem/xdrawchem/molecule_1h_nmr.cpp
+++ b/xdrawchem/xdrawchem/molecule_1h_nmr.cpp
@@ -133,12 +133,13 @@ void Molecule::AddNMRprotons()
 
 void Molecule::RemoveNMRprotons()
 {
-    for (Bond *tmp_bond : bonds) {
-        if ( tmp_bond->End()->nmr_proton == true ) {
-            bonds.removeAll( tmp_bond );
-            delete tmp_bond;
+    int i;
 
-            tmp_bond = bonds.first();
+    for ( i = bonds.size() - 1; i >= 0; --i ) {
+        Bond *tmp_bond = bonds[i];
+        if ( tmp_bond->End()->nmr_proton == true ) {
+            delete tmp_bond;
+            bonds.removeAt(i);
         }
     }
 }


### PR DESCRIPTION
The original implementation of `Molecule::RemoveNMRprotons()` used a range-based for loop to iterate over the bonds container while actively deleting elements and calling `bonds.removeAll()`. Modifying a container during active traversal invalidates the underlying iterators.

While this bug might fail silently or corrupt memory quietly on some platforms, OpenBSD's hardened malloc(3) allocator aggressively flags stale memory access and "junked" pointers, causing an immediate process abort (Signal 11).

```
Thread 1 "" received signal SIGSEGV, Segmentation fault.
0x00000896cc39d410 in Molecule::RemoveNMRprotons() ()
(gdb) bt
#0  0x00000896cc39d410 in Molecule::RemoveNMRprotons() ()
#1  0x00000896cc399173 in Molecule::Calc1HNMR(bool) ()
#2  0x00000896cc42850a in Tool_1HNMR_Dialog::process() ()
#3  0x00000896cc37b142 in ChemData::Tool(DPoint*, int) ()
#4  0x00000896cc403ebf in Render2D::mouseReleaseEvent(QMouseEvent*) ()
#5  0x00000899054fdd90 in QWidget::event(QEvent*) () from /usr/local/lib/libQt6Widgets.so.6.0
#6  0x000008990549b1d9 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/local/lib/libQt6Widgets.so.6.0
#7  0x000008990549d839 in QApplication::notify(QObject*, QEvent*) () from /usr/local/lib/libQt6Widgets.so.6.0
#8  0x00000899730d0680 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /usr/local/lib/libQt6Core.so.8.0
#9  0x000008990549b92d in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) () from /usr/local/lib/libQt6Widgets.so.6.0
#10 0x0000089905519437 in QWidgetWindow::handleMouseEvent(QMouseEvent*) () from /usr/local/lib/libQt6Widgets.so.6.0
#11 0x00000899055185cb in QWidgetWindow::event(QEvent*) () from /usr/local/lib/libQt6Widgets.so.6.0
#12 0x000008990549b1d9 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/local/lib/libQt6Widgets.so.6.0
#13 0x000008990549c2bc in QApplication::notify(QObject*, QEvent*) () from /usr/local/lib/libQt6Widgets.so.6.0
#14 0x00000899730d0680 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /usr/local/lib/libQt6Core.so.8.0
#15 0x0000089900fcd4b8 in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) () from /usr/local/lib/libQt6Gui.so.10.0
#16 0x00000899010423f0 in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/local/lib/libQt6Gui.so.10.0
#17 0x00000899c9d58e73 in xcbSourceDispatch(_GSource*, int (*)(void*), void*) () from /usr/local/lib/qt6/plugins/platforms/../../../libQt6XcbQpa.so.5.0
#18 0x00000898d5da8f8c in g_main_context_dispatch_unlocked () from /usr/local/lib/libglib-2.0.so.4201.16
#19 0x00000898d5da9462 in g_main_context_iterate_unlocked () from /usr/local/lib/libglib-2.0.so.4201.16
#20 0x00000898d5da950b in g_main_context_iteration () from /usr/local/lib/libglib-2.0.so.4201.16
#21 0x00000899733a04f5 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/local/lib/libQt6Core.so.8.0
#22 0x00000899730db595 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/local/lib/libQt6Core.so.8.0
#23 0x00000899730d0ecd in QCoreApplication::exec() () from /usr/local/lib/libQt6Core.so.8.0
#24 0x00000896cc4308ec in main () 
```

Switch the loop logic to an index-based reverse traversal loop. Iterating backward ensures that when an element is removed via `bonds.removeAt(i)`, only the elements already processed shift positions. The upcoming loop index remains perfectly intact and valid. This approach avoids explicit iterator syntax, ensuring backwards and forwards compatibility across all generations of Qt.